### PR TITLE
max-width-patch

### DIFF
--- a/magnifier.css
+++ b/magnifier.css
@@ -35,7 +35,8 @@
 
 .magnifier-large {
     position: absolute;
-    z-index: 100
+    z-index: 100;
+    max-width: none;
 }
 
 .magnifier-preview {


### PR DESCRIPTION
Large preview image looks distorted when img tags are set as max-width:100%. (I find many css frameworks commonly do this)

May be worth having this set to max-width none to catch this problem.

Thanks.
